### PR TITLE
feat: Added save-clear command

### DIFF
--- a/gogdl/args.py
+++ b/gogdl/args.py
@@ -173,5 +173,4 @@ def init_parser():
         required=True,
     )
 
-
     return parser.parse_known_args()

--- a/gogdl/args.py
+++ b/gogdl/args.py
@@ -152,4 +152,26 @@ def init_parser():
         required=True,
     )
 
+    clear_parser = subparsers.add_parser("save-clear", help="Clear cloud game saves")
+    clear_parser.add_argument("path", help="Path to sync files")
+    clear_parser.add_argument("id", help="Game id")
+    clear_parser.add_argument(
+        "--token",
+        "-t",
+        dest="token",
+        help="Provide refresh_token to generate game specific auth keys",
+        required=False,
+    )
+    clear_parser.add_argument("--name", dest="dirname", default="__default")
+
+    clear_parser.add_argument(
+        "--os",
+        "--platform",
+        dest="platform",
+        help="Target opearting system",
+        choices=["windows", "osx", "linux"],
+        required=True,
+    )
+
+
     return parser.parse_known_args()

--- a/gogdl/cli.py
+++ b/gogdl/cli.py
@@ -38,6 +38,7 @@ def main():
         "info": download_manager.calculate_download_size,
         "launch": launch.launch,
         "save-sync": clouds_storage_manager.sync,
+        "save-clear": clouds_storage_manager.clear,
     }
 
     function = switcher.get(arguments.command)

--- a/gogdl/saves.py
+++ b/gogdl/saves.py
@@ -169,6 +169,21 @@ class CloudStorageManager:
         sys.stdout.flush()
         self.logger.info("Done")
 
+    def clear(self, arguments, unknown_args):
+        self.sync_path = os.path.normpath(arguments.path.strip('"'))
+        self.sync_path = self.sync_path.replace("\\", os.sep)
+        self.cloud_save_dir_name = arguments.dirname
+        self.arguments = arguments
+        self.unknown_args = unknown_args
+
+        self.client_id, self.client_secret = self.get_auth_ids()
+        self.get_auth_token()
+
+        cloud_files = self.get_cloud_files_list()
+        for f in cloud_files:
+            self.delete_file(f)
+        self.logger.info("Done")
+
     def get_auth_token(self):
         url = self._get_token_gen_url(self.client_id, self.client_secret)
 


### PR DESCRIPTION
## Why

There is currently no solution to remove files from the cloud. A user might want to remove their files from the cloud for privacy reasons, or they might have uploaded the wrong folder on accident and included personal information in those files.

## How

This PR extends the existing command pool by adding a `save-clear` command to the cli. This command doesn't take all the arguments of `save-sync` since most of them are unnecessary.

It requires `path`, `id` and `--os|platform` arguments, and accepts `--token` and `--name` arguments.

The command lists all the files in the cloud and uses the existing `remove_file(file)` method to send a DELETE request for each. If it succeeds, the cloud bucket for the game will be empty.

## Testing

I've tested this by uploading a miscelanious amount of random files, verifying they indeed existed by downloading them and then verifying that they would no longer download after running this command.

## Future Plans

I intend to open a PR in the Heroic Launcher repo if/when this gets merged, adding the ability for Heroic users to clear their cloud saves at any time from the Game Settings.