### PR TITLE
feat: more verbose progress report, implement PR_CHILD_SUBREAPER

### DIFF
--- a/gogdl/__init__.py
+++ b/gogdl/__init__.py
@@ -9,4 +9,4 @@
 """
 
 
-version = "0.4"
+version = "0.5"

--- a/gogdl/cli.py
+++ b/gogdl/cli.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("MAIN")
 
 
 def display_version():
-    print(f"Version: {gogdl_version}")
+    print(f"{gogdl_version}")
 
 
 def main():

--- a/gogdl/dl/dl_utils.py
+++ b/gogdl/dl/dl_utils.py
@@ -4,7 +4,9 @@ import os
 import gogdl.constants as constants
 import shutil
 from sys import exit
+
 PATH_SEPARATOR = os.sep
+
 
 def get_json(api_handler, url):
     x = api_handler.session.get(url)
@@ -27,34 +29,35 @@ def get_zlib_encoded(api_handler, url):
 def prepare_location(path, logger=None):
     os.makedirs(path, exist_ok=True)
     if logger:
-        logger.debug(f'Created directory {path}')
+        logger.debug(f"Created directory {path}")
+
 
 # V1 Compatible
 def galaxy_path(manifest: str):
     galaxy_path = manifest
-    if galaxy_path.find('/') == -1:
-        galaxy_path = manifest[0:2]+'/'+manifest[2:4]+'/'+galaxy_path
+    if galaxy_path.find("/") == -1:
+        galaxy_path = manifest[0:2] + "/" + manifest[2:4] + "/" + galaxy_path
     return galaxy_path
 
 
 def get_secure_link(api_handler, path, gameId, generation=2):
-    url = ''
+    url = ""
     if generation == 2:
-        url = f'{constants.GOG_CONTENT_SYSTEM}/products/{gameId}/secure_link?_version=2&generation=2&path={path}'
+        url = f"{constants.GOG_CONTENT_SYSTEM}/products/{gameId}/secure_link?_version=2&generation=2&path={path}"
     elif generation == 1:
-        url = f'{constants.GOG_CONTENT_SYSTEM}/products/{gameId}/secure_link?_version=2&type=depot&path={path}'
+        url = f"{constants.GOG_CONTENT_SYSTEM}/products/{gameId}/secure_link?_version=2&type=depot&path={path}"
     r = api_handler.session.get(url)
     if not r.ok:
-            print(f'ERROR getting secure link for {path}')
-            exit(1)
+        print(f"ERROR getting secure link for {path}")
+        exit(1)
     js = r.json()
 
-    endpoint = classify_cdns(js['urls'], generation)
-    url_format = endpoint['url_format']
-    parameters = endpoint['parameters']
+    endpoint = classify_cdns(js["urls"], generation)
+    url_format = endpoint["url_format"]
+    parameters = endpoint["parameters"]
     if generation == 1:
-        if parameters.get('path'):
-            parameters['path'] = parameters['path']+'/main.bin'
+        if parameters.get("path"):
+            parameters["path"] = parameters["path"] + "/main.bin"
 
         return merge_url_with_params(url_format, parameters)
 
@@ -62,79 +65,90 @@ def get_secure_link(api_handler, path, gameId, generation=2):
 
 
 def get_dependency_link(api_handler, path):
-    data = get_json(api_handler, f'{constants.GOG_CONTENT_SYSTEM}/open_link?generation=2&_version=2&path=/dependencies/store/' + path)
-    endpoint = classify_cdns(data['urls'])
-    url = endpoint['url']
+    data = get_json(
+        api_handler,
+        f"{constants.GOG_CONTENT_SYSTEM}/open_link?generation=2&_version=2&path=/dependencies/store/"
+        + path,
+    )
+    endpoint = classify_cdns(data["urls"])
+    url = endpoint["url"]
     return url
 
 
 def merge_url_with_params(url, parameters):
     for key in parameters.keys():
-        url = url.replace('{'+key+'}', str(parameters[key]))
+        url = url.replace("{" + key + "}", str(parameters[key]))
         if not url:
             print(f"Error ocurred getting a secure link: {url}")
     return url
 
+
 def parent_dir(path: str):
-    return path[0:path.rindex(PATH_SEPARATOR)]
+    return path[0 : path.rindex(PATH_SEPARATOR)]
 
 
 def classify_cdns(array, generation=2):
     cdns = list()
     for item in array:
         score = 0
-        endpoint_name = item['endpoint_name']
+        endpoint_name = item["endpoint_name"]
         # Some CDNS are failing to process a request propertly
         # cdn = filterCdns(endpoint_name, constants.GALAXY_CDNS)
         # if cdn:
         cdns.append(item)
     best = None
     for cdn in cdns:
-        if not generation in cdn['supports_generation']:
+        if not generation in cdn["supports_generation"]:
             continue
         if not best:
             best = cdn
         else:
-            if best['priority'] > cdn['priority']:
+            if best["priority"] > cdn["priority"]:
                 best = cdn
-    
+
     return best
 
-        
+
 # def filterCdns(string,  options):
 #     for option in options:
 #         if string == option:
 #             return True
-#     return False 
+#     return False
 
-def calculate_sum(path, function):
-    with open(path, 'rb') as f:
+
+def calculate_sum(path, function, read_speed_function=None):
+    with open(path, "rb") as f:
         calculate = function()
         while True:
             chunk = f.read(16 * 1024)
             if not chunk:
                 break
+            if read_speed_function:
+                read_speed_function(len(chunk))
             calculate.update(chunk)
 
         return calculate.hexdigest()
 
+
 def get_readable_size(size):
     power = 2**10
     n = 0
-    power_labels = {0 : '', 1: 'K', 2: 'M', 3: 'G'}
+    power_labels = {0: "", 1: "K", 2: "M", 3: "G"}
     while size > power:
         size /= power
         n += 1
-    return size, power_labels[n]+'B'
+    return size, power_labels[n] + "B"
+
 
 def check_free_space(size, path):
     if not os.path.exists(path):
-        os.makedirs(path,exist_ok=True)
-    _,_,available_space = shutil.disk_usage(path)
+        os.makedirs(path, exist_ok=True)
+    _, _, available_space = shutil.disk_usage(path)
 
     return size < available_space
 
+
 def get_range_header(offset, size):
     from_value = offset
-    to_value = (int(offset) + int(size))-1
-    return f'bytes={from_value}-{to_value}'
+    to_value = (int(offset) + int(size)) - 1
+    return f"bytes={from_value}-{to_value}"

--- a/gogdl/dl/linux_native.py
+++ b/gogdl/dl/linux_native.py
@@ -189,14 +189,16 @@ def get_file(url, path, api_handler, md5):
     with open(path, "ab") as f:
         if total is None:
             f.write(response.content)
+            progress_bar.update_bytes_written(len(response.content))
+            progress_bar.update_download_speed(len(response.content))
         else:
             total = int(total)
             for data in response.iter_content(
                 chunk_size=max(int(total / 1000), 1024 * 1024)
             ):
-                f.write(data)
                 progress_bar.update_download_speed(len(data))
-                progress_bar.update_downloaded_size(len(data))
+                written = f.write(data)
+                progress_bar.update_bytes_written(written)
     f.close()
     progress_bar.completed = True
     progress_bar.join()

--- a/gogdl/dl/progressbar.py
+++ b/gogdl/dl/progressbar.py
@@ -49,7 +49,7 @@ class ProgressBar(threading.Thread):
             estimated_h = int(estimated_time // 3600)
             estimated_time = estimated_time % 3600
             estimated_m = int(estimated_time // 60)
-            estimated_s = int(running_time % 60)
+            estimated_s = int(estimated_time % 60)
 
             write_speed = self.written_since_last_update / time_since_last_update
             read_speed = self.read_since_last_update / time_since_last_update

--- a/gogdl/process.py
+++ b/gogdl/process.py
@@ -1,0 +1,138 @@
+import os
+
+
+class InvalidPid(Exception):
+
+    """Exception raised when an operation on a non-existent PID is called"""
+
+
+class Process:
+
+    """Python abstraction a Linux process"""
+
+    def __init__(self, pid):
+        try:
+            self.pid = int(pid)
+            self.error_cache = []
+        except ValueError as err:
+            raise InvalidPid("'%s' is not a valid pid" % pid) from err
+
+    def __repr__(self):
+        return "Process {}".format(self.pid)
+
+    def __str__(self):
+        return "{} ({}:{})".format(self.name, self.pid, self.state)
+
+    def _read_content(self, file_path):
+        """Return the contents from a file in /proc"""
+        try:
+            with open(file_path, encoding='utf-8') as proc_file:
+                content = proc_file.read()
+        except (ProcessLookupError, FileNotFoundError, PermissionError):
+            return ""
+        return content
+
+    def get_stat(self, parsed=True):
+        stat_filename = "/proc/{}/stat".format(self.pid)
+        try:
+            with open(stat_filename, encoding='utf-8') as stat_file:
+                _stat = stat_file.readline()
+        except (ProcessLookupError, FileNotFoundError):
+            return None
+        if parsed:
+            return _stat[_stat.rfind(")") + 1:].split()
+        return _stat
+
+    def get_thread_ids(self):
+        """Return a list of thread ids opened by process."""
+        basedir = "/proc/{}/task/".format(self.pid)
+        if os.path.isdir(basedir):
+            try:
+                return os.listdir(basedir)
+            except FileNotFoundError:
+                return []
+        else:
+            return []
+
+    def get_children_pids_of_thread(self, tid):
+        """Return pids of child processes opened by thread `tid` of process."""
+        children_path = "/proc/{}/task/{}/children".format(self.pid, tid)
+        try:
+            with open(children_path, encoding='utf-8') as children_file:
+                children_content = children_file.read()
+        except (FileNotFoundError, ProcessLookupError):
+            children_content = ""
+        return children_content.strip().split()
+
+    @property
+    def name(self):
+        """Filename of the executable."""
+        _stat = self.get_stat(parsed=False)
+        if _stat:
+            return _stat[_stat.find("(") + 1:_stat.rfind(")")]
+        return None
+
+    @property
+    def state(self):
+        """One character from the string "RSDZTW" where R is running, S is
+        sleeping in an interruptible wait, D is waiting in uninterruptible disk
+        sleep, Z is zombie, T is traced or stopped (on a signal), and W is
+        paging.
+        """
+        _stat = self.get_stat()
+        if _stat:
+            return _stat[0]
+        return None
+
+    @property
+    def cmdline(self):
+        """Return command line used to run the process `pid`."""
+        cmdline_path = "/proc/{}/cmdline".format(self.pid)
+        _cmdline_content = self._read_content(cmdline_path)
+        if _cmdline_content:
+            return _cmdline_content.replace("\x00", " ").replace("\\", "/")
+
+    @property
+    def cwd(self):
+        """Return current working dir of process"""
+        cwd_path = "/proc/%d/cwd" % int(self.pid)
+        return os.readlink(cwd_path)
+
+    @property
+    def environ(self):
+        """Return the process' environment variables"""
+        environ_path = "/proc/{}/environ".format(self.pid)
+        _environ_text = self._read_content(environ_path)
+        if not _environ_text:
+            return {}
+        try:
+            return dict([line.split("=", 1) for line in _environ_text.split("\x00") if line])
+        except ValueError:
+            if environ_path not in self.error_cache:
+                self.error_cache.append(environ_path)
+            return {}
+
+    @property
+    def children(self):
+        """Return the child processes of this process"""
+        _children = []
+        for tid in self.get_thread_ids():
+            for child_pid in self.get_children_pids_of_thread(tid):
+                _children.append(Process(child_pid))
+        return _children
+
+    def iter_children(self):
+        """Iterator that yields all the children of a process"""
+        for child in self.children:
+            yield child
+            yield from child.iter_children()
+
+    def wait_for_finish(self):
+        """Waits until the process finishes
+        This only works if self.pid is a child process of Lutris
+        """
+        try:
+            pid, ret_status = os.waitpid(int(self.pid) * -1, 0)
+        except OSError as ex:
+            return -1
+        return ret_status


### PR DESCRIPTION
Progress now reports stats like disk activity.

With this all child processes are handled by gogdl.  
So killing gogdl will kill sub processes etc..

This change allows us to track all processes. Eliminates risk when process "escapes" and gogdl exits, making Heroic think game is not started.

Also uses brilliant abstraction used in `lutris-wrapper` for `/proc` serialization