### PR TITLE
Retry save sync download if connection failed

### DIFF
--- a/gogdl/saves.py
+++ b/gogdl/saves.py
@@ -273,9 +273,9 @@ class CloudStorageManager:
             if (retries > 1):
                 self.logger.debug(f"Failed sync of {file}, retrying (retries left {retries - 1})")
                 self.download_file(file, retries - 1)
+                return
             else:
-                response = {"ok": False}
-            return
+                response = {}
 
         if not response.ok:
             self.logger.error("Downloading file failed")


### PR DESCRIPTION
When syncing saves, sometimes the connection to download a file fails raising an exception. When that happens, the syncing stops completely because the exception is not catch.

This PR adds a try/except block around that and also 3 retries to download the file in case it was just a connection hiccup.