### PR TITLE
Fix stale downloads

### DIFF
--- a/gogdl/dl/dl_utils.py
+++ b/gogdl/dl/dl_utils.py
@@ -3,6 +3,7 @@ import zlib
 import os
 import gogdl.constants as constants
 import shutil
+import time
 from sys import exit
 
 PATH_SEPARATOR = os.sep
@@ -49,7 +50,9 @@ def get_secure_link(api_handler, path, gameId, generation=2):
     r = api_handler.session.get(url)
     if not r.ok:
         print(f"ERROR getting secure link for {path}")
-        exit(1)
+        time.sleep(0.2)
+        return get_secure_link(api_handler, path, gameId, generation)
+
     js = r.json()
 
     endpoint = classify_cdns(js["urls"], generation)

--- a/gogdl/dl/worker.py
+++ b/gogdl/dl/worker.py
@@ -139,6 +139,7 @@ class DLWorker:
             if not response.ok:
                 self.api_handler.get_new_secure_link(self.data.product_id)
                 self.get_file(path, compressed_sum, decompressed_sum, index)
+                return
 
             total = response.headers.get("Content-Length")
             if total is None:


### PR DESCRIPTION
This PR is my attempt to fix the issue some users are experiencing when a download gets stale after around 10minutes.

After a lot of debugging I got to this fix.

I understand there were 2 issues:
- after the refactor, the first call to `get_new_secure_link` starts fetching a new link and any other thread waits for that first one to finish (in the while True loop), but if the first one that is actually trying to get a new link fails, then it never sets the new endpoint and everything else just keeps there waiting forever (that's my attempted fix removing the `exit`)
- when a `response.ok` is False in the get_file method, we are calling `get_file` again but not returning, so the original `get_file` is still running with an invalid response

With this changes I don't have the issue I was having consistently. There's the other issue where the token expires, but I understand it's unrelated to this problem.