### PR TITLE
Fix: Remove possible division by zero by removing unused variable

### DIFF
--- a/gogdl/dl/progressbar.py
+++ b/gogdl/dl/progressbar.py
@@ -39,7 +39,7 @@ class ProgressBar(threading.Thread):
             time_since_last_update = time() - self.last_update
             size_left = self.total - self.downloaded
 
-            average_speed = self.downloaded / running_time
+            # average_speed = self.downloaded / running_time
 
             if percentage > 0:
                 estimated_time = (100 * running_time) / percentage - running_time


### PR DESCRIPTION
An unused variable turned out to be causing my issue #27.
I just commented it since it's not used anywhere, if it serves a purpose I'd recommend adding a check for never dividing by zero.