### PR TITLE
download_refactor: Guarantee workers_count is an int

### DIFF
--- a/gogdl/dl/managers/manager.py
+++ b/gogdl/dl/managers/manager.py
@@ -19,7 +19,7 @@ class Manager:
         self.game_id = arguments.id
         self.branch = arguments.branch or None
         if "workers_count" in arguments:
-            self.allowed_threads = arguments.workers_count
+            self.allowed_threads = int(arguments.workers_count)
         else:
             self.allowed_threads = cpu_count()
 

--- a/gogdl/dl/managers/v2.py
+++ b/gogdl/dl/managers/v2.py
@@ -92,6 +92,7 @@ class Manager:
 
         # Load old manifest
         if os.path.exists(manifest_path):
+            self.logger.debug(f"Loading existing manifest for game {self.game_id}")
             with open(manifest_path, 'r') as f_handle:
                 try:
                     json_data = json.load(f_handle)


### PR DESCRIPTION
After a bit more testing, I found that I was actually getting a crash due to workers_count being interpreted as a str instead of an int. Casting to int in the top-level manager makes this a non-issue.
I've also included a debug log that was useful for troubleshooting