### PR TITLE
Catch 'TypeError' too while processing cloud saves

### DIFF
--- a/gogdl/saves.py
+++ b/gogdl/saves.py
@@ -299,7 +299,7 @@ class CloudStorageManager:
                 .timestamp()
             )
             os.utime(file.absolute_path, (f_timestamp, f_timestamp))
-        except ValueError:
+        except (ValueError, TypeError):
             self.logger.warning(f"Incorrect LastModified header for file {file.relative_path} {response.headers.get('X-Object-Meta-LocalLastModified')} ; Ignoring...")
             pass 
 


### PR DESCRIPTION
From this issue in discord: https://discord.com/channels/812703221789097985/1196160070032044124

Looks like we have to catch TypeError too, not only ValueError