### PR TITLE
fix: error on dlc if no installer (log error and ignore) #48

### DIFF
--- a/gogdl/dl/managers/linux.py
+++ b/gogdl/dl/managers/linux.py
@@ -110,6 +110,13 @@ class Manager:
 
                     linux_installers = self.filter_linux_installers(dlc["downloads"]["installers"])
                     installer = self.find_matching_installer(linux_installers)
+
+                    if installer is None:
+                        self.logger.error(
+                            dlc["title"] + " - Does not have a linux installer"
+                        )
+                        continue
+
                     installer_data = dl_utils.get_json(self.api_handler, installer["files"][0]["downlink"])
 
                     install_handler = linux.InstallerHandler(installer_data["downlink"],


### PR DESCRIPTION
It seems that DLCs for some games with Linux don't have installers such as Battletech Digital Deluxe Content #48

This is a quick fix to allow for the software not to crash - it skips over DLC's that don't have a matching installer and logs the titles of the DLCs.