### PR TITLE
Remove explicit max-parallel value in workflow file

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,6 @@ jobs:
   build:
     strategy:
       fail-fast: false
-      max-parallel: 3
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04-arm, macos-13, macos-14, windows-2022]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Not really a reason to limit this