### PR TITLE
Implement ability to exclude files from download

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,6 @@ jobs:
   build:
     strategy:
       fail-fast: false
-      max-parallel: 3
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-15, windows-2025]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ubuntu-22.04-arm, macos-13, macos-14, windows-2022]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-15, windows-2025]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04-arm, macos-13, macos-14, windows-2022]
+        os: [ubuntu-22.04-arm, macos-13, macos-14, windows-2022]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/gogdl/dl/managers/linux.py
+++ b/gogdl/dl/managers/linux.py
@@ -251,6 +251,7 @@ class Manager:
 
         with open(os.path.join(constants.CONFIG_DIR, "exclude", self.game_id), "r") as f:
             exclude_list = [line.strip().lower() for line in f if line.strip()]
+            exclude_list = [pattern.replace('/', os.sep).replace('\\', os.sep) for pattern in exclude_list]
 
         final_files = list()
         for i, file in enumerate(new):

--- a/gogdl/dl/managers/v1.py
+++ b/gogdl/dl/managers/v1.py
@@ -164,6 +164,10 @@ class Manager:
 
         if self.manifest:
             self.manifest.get_files()
+            for file in self.manifest.files:
+                self.logger.info(file.path)
+            self.manifest.exclude_files()
+            
 
         if old_manifest:
             old_manifest.get_files()

--- a/gogdl/dl/managers/v1.py
+++ b/gogdl/dl/managers/v1.py
@@ -164,8 +164,6 @@ class Manager:
 
         if self.manifest:
             self.manifest.get_files()
-            for file in self.manifest.files:
-                self.logger.info(file.path)
             self.manifest.exclude_files()
             
 

--- a/gogdl/dl/managers/v2.py
+++ b/gogdl/dl/managers/v2.py
@@ -130,6 +130,7 @@ class Manager:
         if self.manifest:
             self.logger.debug("Requesting files of primary manifest")
             self.manifest.get_files()
+            self.manifest.exclude_files()
         if old_manifest:
             self.logger.debug("Requesting files of previous manifest")
             old_manifest.get_files()

--- a/gogdl/dl/objects/generic.py
+++ b/gogdl/dl/objects/generic.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 from enum import Flag, auto
+from fnmatch import fnmatch
+import os
 from typing import Optional
 
 
@@ -91,3 +93,14 @@ class FileTask:
 @dataclass
 class TerminateWorker:
     pass
+
+class FileExlusion:
+    def matches(file, exclude_list):
+                for pattern in exclude_list:
+                    if '/' in pattern and '/' in file.path: #If pattern contains a seperator, check dirname and basename seperately. Ensures that only files in specified directories are excluded.
+                        if os.path.dirname(file.path) == os.path.dirname(pattern) and fnmatch(os.path.basename(file.path), os.path.basename(pattern)):
+                            return True
+                    else:
+                        if fnmatch(file.path, pattern):
+                            return True
+                return False

--- a/gogdl/dl/objects/generic.py
+++ b/gogdl/dl/objects/generic.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Flag, auto
-from fnmatch import fnmatch
+from pathlib import PurePath
 import os
 from typing import Optional
 
@@ -97,10 +97,6 @@ class TerminateWorker:
 class FileExclusion:
     def matches(file, excludelist):
         for pattern in excludelist:
-            if '/' in file and not pattern.endswith('*') and not pattern.startswith('*'):
-                if os.path.dirname(file) == os.path.dirname(pattern) and fnmatch(os.path.basename(file), os.path.basename(pattern)):
-                    return True
-            else:
-                if fnmatch(file,pattern):
-                    return True
+            if PurePath(file).full_match(pattern):
+                return True
         return False

--- a/gogdl/dl/objects/generic.py
+++ b/gogdl/dl/objects/generic.py
@@ -94,13 +94,13 @@ class FileTask:
 class TerminateWorker:
     pass
 
-class FileExlusion:
-    def matches(file, exclude_list):
-                for pattern in exclude_list:
-                    if '/' in pattern and '/' in file.path: #If pattern contains a seperator, check dirname and basename seperately. Ensures that only files in specified directories are excluded.
-                        if os.path.dirname(file.path) == os.path.dirname(pattern) and fnmatch(os.path.basename(file.path), os.path.basename(pattern)):
-                            return True
-                    else:
-                        if fnmatch(file.path, pattern):
-                            return True
-                return False
+class FileExclusion:
+    def matches(file, excludelist):
+        for pattern in excludelist:
+            if '/' in file and not pattern.endswith('*') and not pattern.startswith('*'):
+                if os.path.dirname(file) == os.path.dirname(pattern) and fnmatch(os.path.basename(file), os.path.basename(pattern)):
+                    return True
+            else:
+                if fnmatch(file,pattern):
+                    return True
+        return False

--- a/gogdl/dl/objects/v1.py
+++ b/gogdl/dl/objects/v1.py
@@ -134,10 +134,10 @@ class Manifest:
         try:
             with open(os.path.join(constants.CONFIG_DIR, "exclude", self.product_id), "r") as f:
                 exclude_list = [line.strip().lower() for line in f if line.strip()]
-                exclude_list = [pattern.replace('/', os.sep) for pattern in exclude_list]
+                exclude_list = [pattern.replace('/', os.sep).replace('\\', os.sep) for pattern in exclude_list]
         except Exception:
             return
-        self.files = [file for file in self.files if not FileExclusion.matches(file.path.lower(), exclude_list)]
+        self.files = [file for file in self.files if not FileExclusion.matches(file.path.lower().replace('/', os.sep).replace('\\', os.sep), exclude_list)]
 
 class ManifestDiff(generic.BaseDiff):
     def __init__(self):

--- a/gogdl/dl/objects/v1.py
+++ b/gogdl/dl/objects/v1.py
@@ -4,7 +4,7 @@ from gogdl.dl import dl_utils
 from gogdl.dl.objects import generic, v2
 from gogdl import constants
 from gogdl.languages import Language
-from gogdl.dl.objects.generic import FileExlusion
+from gogdl.dl.objects.generic import FileExclusion
 
 
 class Depot:
@@ -133,12 +133,11 @@ class Manifest:
     def exclude_files(self):
         try:
             with open(os.path.join(constants.CONFIG_DIR, "exclude", self.product_id), "r") as f:
-                exclude_list = [line.strip() for line in f if line.strip()]
-                #Only checks file list so we dont normalize the path seperator. Files objects use linux style paths, even on windows.
+                exclude_list = [line.strip().lower() for line in f if line.strip()]
+                exclude_list = [pattern.replace('/', os.sep) for pattern in exclude_list]
         except Exception:
             return
-
-        self.files = [file for file in self.files if not FileExlusion.matches(file, exclude_list)]
+        self.files = [file for file in self.files if not FileExclusion.matches(file.path.lower(), exclude_list)]
 
 class ManifestDiff(generic.BaseDiff):
     def __init__(self):

--- a/gogdl/dl/objects/v1.py
+++ b/gogdl/dl/objects/v1.py
@@ -4,6 +4,7 @@ from gogdl.dl import dl_utils
 from gogdl.dl.objects import generic, v2
 from gogdl import constants
 from gogdl.languages import Language
+from gogdl.dl.objects.generic import FileExlusion
 
 
 class Depot:
@@ -128,6 +129,16 @@ class Manifest:
                     self.dirs.append(Directory(record)) 
                 else:
                     self.files.append(File(record, depot.game_ids[0]))
+
+    def exclude_files(self):
+        try:
+            with open(os.path.join(constants.CONFIG_DIR, "exclude", self.product_id), "r") as f:
+                exclude_list = [line.strip() for line in f if line.strip()]
+                #Only checks file list so we dont normalize the path seperator. Files objects use linux style paths, even on windows.
+        except Exception:
+            return
+
+        self.files = [file for file in self.files if not FileExlusion.matches(file, exclude_list)]
 
 class ManifestDiff(generic.BaseDiff):
     def __init__(self):

--- a/gogdl/dl/objects/v2.py
+++ b/gogdl/dl/objects/v2.py
@@ -140,11 +140,11 @@ class Manifest:
         try:
             with open(os.path.join(constants.CONFIG_DIR, "exclude", self.product_id), "r") as f:
                 exclude_list = [line.strip().lower() for line in f if line.strip()]
-                exclude_list = [pattern.replace('/', os.sep) for pattern in exclude_list]
+                exclude_list = [pattern.replace('/', os.sep).replace('\\', os.sep) for pattern in exclude_list]
         except Exception:
             return
 
-        self.files = [file for file in self.files if not FileExclusion.matches(file.path.lower(), exclude_list)]
+        self.files = [file for file in self.files if not FileExclusion.matches(file.path.lower().replace('/', os.sep).replace('\\', os.sep), exclude_list)]
 
 
 class FileDiff:

--- a/gogdl/dl/objects/v2.py
+++ b/gogdl/dl/objects/v2.py
@@ -145,7 +145,7 @@ class Manifest:
 
         def matches(file):
             for pattern in exclude_list:
-                if '/' in pattern: #If pattern contains a seperator, check dirname and basename seperately. Ensures that only files in specified directories are excluded.
+                if '/' in pattern and '/' in file.path: #If pattern contains a seperator, check dirname and basename seperately. Ensures that only files in specified directories are excluded.
                     if os.path.dirname(file.path) == os.path.dirname(pattern) and fnmatch(os.path.basename(file.path), os.path.basename(pattern)):
                         return True
                 else:

--- a/gogdl/dl/objects/v2.py
+++ b/gogdl/dl/objects/v2.py
@@ -6,7 +6,6 @@ from gogdl.dl import dl_utils
 from gogdl.dl.objects import generic, v1
 from gogdl import constants
 from gogdl.languages import Language
-from posixpath import dirname, basename
 
 
 class DepotFile:
@@ -140,13 +139,14 @@ class Manifest:
         try:
             with open(os.path.join(constants.CONFIG_DIR, "exclude", self.product_id), "r") as f:
                 exclude_list = [line.strip() for line in f if line.strip()]
+                exclude_list = [pattern.replace('/', os.sep) for pattern in exclude_list]
         except Exception:
             return
 
         def matches(file):
             for pattern in exclude_list:
                 if '/' in pattern: #If pattern contains a seperator, check dirname and basename seperately. Ensures that only files in specified directories are excluded.
-                    if dirname(file.path) == dirname(pattern) and fnmatch(basename(file.path), basename(pattern)):
+                    if os.path.dirname(file.path) == os.path.dirname(pattern) and fnmatch(os.path.basename(file.path), os.path.basename(pattern)):
                         return True
                 else:
                     if fnmatch(file.path, pattern):

--- a/gogdl/dl/objects/v2.py
+++ b/gogdl/dl/objects/v2.py
@@ -134,6 +134,17 @@ class Manifest:
                 else:
                     self.dirs.append(DepotDirectory(item))
 
+    def exclude_files(self):
+        try:
+            with open(os.path.join(constants.CONFIG_DIR, "exclude", self.product_id), "r") as f:
+                exclude_list = [line.strip() for line in f if line.strip()]
+        except Exception:
+            return
+        self.files = [file for file in self.files if file.path not in exclude_list]
+
+                
+        
+
 class FileDiff:
     def __init__(self):
         self.file: DepotFile

--- a/gogdl/dl/objects/v2.py
+++ b/gogdl/dl/objects/v2.py
@@ -6,6 +6,7 @@ from gogdl.dl import dl_utils
 from gogdl.dl.objects import generic, v1
 from gogdl import constants
 from gogdl.languages import Language
+from gogdl.dl.objects.generic import FileExlusion
 
 
 class DepotFile:
@@ -143,17 +144,7 @@ class Manifest:
         except Exception:
             return
 
-        def matches(file):
-            for pattern in exclude_list:
-                if '/' in pattern and '/' in file.path: #If pattern contains a seperator, check dirname and basename seperately. Ensures that only files in specified directories are excluded.
-                    if os.path.dirname(file.path) == os.path.dirname(pattern) and fnmatch(os.path.basename(file.path), os.path.basename(pattern)):
-                        return True
-                else:
-                    if fnmatch(file.path, pattern):
-                        return True
-            return False
-
-        self.files = [file for file in self.files if not matches(file)]
+        self.files = [file for file in self.files if not FileExlusion.matches(file, exclude_list)]
 
 
 class FileDiff:

--- a/gogdl/dl/objects/v2.py
+++ b/gogdl/dl/objects/v2.py
@@ -1,3 +1,4 @@
+from fnmatch import fnmatch
 import json
 import os
 
@@ -5,6 +6,7 @@ from gogdl.dl import dl_utils
 from gogdl.dl.objects import generic, v1
 from gogdl import constants
 from gogdl.languages import Language
+from posixpath import dirname, basename
 
 
 class DepotFile:
@@ -140,10 +142,19 @@ class Manifest:
                 exclude_list = [line.strip() for line in f if line.strip()]
         except Exception:
             return
-        self.files = [file for file in self.files if file.path not in exclude_list]
 
-                
-        
+        def matches(file):
+            for pattern in exclude_list:
+                if '/' in pattern: #If pattern contains a seperator, check dirname and basename seperately. Ensures that only files in specified directories are excluded.
+                    if dirname(file.path) == dirname(pattern) and fnmatch(basename(file.path), basename(pattern)):
+                        return True
+                else:
+                    if fnmatch(file.path, pattern):
+                        return True
+            return False
+
+        self.files = [file for file in self.files if not matches(file)]
+
 
 class FileDiff:
     def __init__(self):

--- a/gogdl/dl/objects/v2.py
+++ b/gogdl/dl/objects/v2.py
@@ -6,7 +6,7 @@ from gogdl.dl import dl_utils
 from gogdl.dl.objects import generic, v1
 from gogdl import constants
 from gogdl.languages import Language
-from gogdl.dl.objects.generic import FileExlusion
+from gogdl.dl.objects.generic import FileExclusion
 
 
 class DepotFile:
@@ -139,12 +139,12 @@ class Manifest:
     def exclude_files(self):
         try:
             with open(os.path.join(constants.CONFIG_DIR, "exclude", self.product_id), "r") as f:
-                exclude_list = [line.strip() for line in f if line.strip()]
+                exclude_list = [line.strip().lower() for line in f if line.strip()]
                 exclude_list = [pattern.replace('/', os.sep) for pattern in exclude_list]
         except Exception:
             return
 
-        self.files = [file for file in self.files if not FileExlusion.matches(file, exclude_list)]
+        self.files = [file for file in self.files if not FileExclusion.matches(file.path.lower(), exclude_list)]
 
 
 class FileDiff:


### PR DESCRIPTION
This will allow the user to exclude files from being downloaded. Excluding files can be useful if the game includes all the language files in the download regardless of selection upon download (Skyrim) or includes several versions (Divinity Original Sin 2 includes both the classic and enhanced in the download).

Still gonna improve on this a bit like adding support for wildcards (Content/* as an example) and maybe some other stuff 

Exclusion lists go into gogdlConfig/heroic_gogdl/exclude/gameid and files are listed line by line