### PR TITLE
fix: prevent multiple CLI crashes and improve error handling

### DIFF
--- a/gogdl/auth.py
+++ b/gogdl/auth.py
@@ -27,7 +27,7 @@ class AuthorizationManager:
         self.session.auth = lambda r: r
 
     def __read_config(self):
-        if os.path.exists(self.config_path):
+        if self.config_path and os.path.exists(self.config_path):
             with open(self.config_path, "r") as f:
                 self.credentials_data = json.loads(f.read())
                 f.close()

--- a/gogdl/dl/managers/linux.py
+++ b/gogdl/dl/managers/linux.py
@@ -22,6 +22,9 @@ def get_folder_name_from_windows_manifest(api_handler, id):
         f"{constants.GOG_CONTENT_SYSTEM}/products/{id}/os/windows/builds?generation=2",
     )
 
+    if not builds.get("items"):
+        return "UnknownGame"
+
     url = builds["items"][0]["link"]
     meta, headers = dl_utils.get_zlib_encoded(api_handler, url)
     install_dir = (
@@ -62,7 +65,7 @@ class Manager:
         self.logger.info("Initialized Linux Download Manager")
 
         self.game_data = None
-
+        self.game_installer = {"version": "Unknown"}
         self.languages_codes = list()
         self.downlink = None
         self.game_files = list()
@@ -89,6 +92,11 @@ class Manager:
 
     def setup(self):
         self.game_data = self.api_handler.get_item_data(self.game_id, expanded=['downloads', 'expanded_dlcs'])
+
+        if not self.game_data: # Adicionado este bloco de proteção
+            self.logger.error("Could not fetch game data. Check your connection or auth.")
+            self.game_data = {"downloads": {"installers": []}, "expanded_dlcs": []}
+            return
 
         # Filter linux installers
         game_installers = self.filter_linux_installers(self.game_data["downloads"]["installers"])


### PR DESCRIPTION
This commit addresses several stability issues when using the CLI:
- auth.py: Added a check for config_path to avoid TypeError if it's None.
- linux.py: Added a safety check in get_folder_name_from_windows_manifest to prevent IndexError when no builds are found.
- linux.py: Improved Manager.setup() to handle 404/None responses from the GOG API gracefully.
- linux.py: Initialized default attributes in Manager.__init__ to prevent AttributeError when setup() fails or returns early.