### PR TITLE
Add more logging to --debug level

### DIFF
--- a/gogdl/cli.py
+++ b/gogdl/cli.py
@@ -29,6 +29,7 @@ def main():
     if '-d' in unknown_args or '--debug' in unknown_args:
         level = logging.DEBUG
     logging.basicConfig(format="[%(name)s] %(levelname)s: %(message)s", level=level)
+    logging.getLogger("urllib3").setLevel(level)
     logger = logging.getLogger("MAIN")
     logger.debug(arguments)
     if arguments.display_version:

--- a/gogdl/saves.py
+++ b/gogdl/saves.py
@@ -221,6 +221,7 @@ class CloudStorageManager:
         json_res = response.json()
         # print(json_res)
         self.logger.info(f"Files in cloud: {len(json_res)}")
+        self.logger.debug(f"Files: {json_res}")
 
         filtered = filter(self.is_in_our_dir, json_res)
 
@@ -255,6 +256,7 @@ class CloudStorageManager:
         response = self.session.delete(
             f"{constants.GOG_CLOUDSTORAGE}/v1/{self.credentials['user_id']}/{self.client_id}/{self.cloud_save_dir_name}/{fpath}",
         )
+        self.logger.debug(f"Delete response: {response}")
 
     def upload_file(self, file: SyncFile):
         compressed_data = gzip.compress(
@@ -296,6 +298,8 @@ class CloudStorageManager:
 
         if not response.ok:
             self.logger.error("Downloading file failed")
+            self.logger.debug(f"Download error: {response}")
+            return
 
         total = response.headers.get("Content-Length")
         os.makedirs(os.path.split(file.absolute_path)[0], exist_ok=True)
@@ -325,6 +329,7 @@ class CloudStorageManager:
         response = self.session.post(f"{constants.GOG_CLOUDSTORAGE}/v1/{self.credentials['user_id']}/{self.client_id}")
         if not response.ok:
             self.logger.error("Failed to commit")
+            self.logger.debug(f"Commit error: {response}")
 
 
 class SyncClassifier:


### PR DESCRIPTION
This was very helpful when debugging #78 since I could trace what GoG API returns without recompiling everything constantly on the Deck.