### PR TITLE
Fix 83 - IPv6 and Timeouts

### DIFF
--- a/gogdl/auth.py
+++ b/gogdl/auth.py
@@ -5,6 +5,7 @@ import logging
 import os.path
 import requests
 import time
+from gogdl import net
 from gogdl import version
 
 CODE_URL = "https://auth.gog.com/token?client_id=46899977096215655&client_secret=9d85c43b1482497dbbce61f6e4aa173a433796eeae2ca8c5f6129f2dc4de46d9&grant_type=authorization_code&redirect_uri=https%3A%2F%2Fembed.gog.com%2Fon_login_success%3Forigin%3Dclient&code="
@@ -14,7 +15,7 @@ CLIENT_SECRET = "9d85c43b1482497dbbce61f6e4aa173a433796eeae2ca8c5f6129f2dc4de46d
 
 class AuthorizationManager:
     def __init__(self, config_path):
-        self.session = requests.session()
+        self.session = net.Session()
         self.logger = logging.getLogger("AUTH")
 
         self.config_path = config_path
@@ -120,7 +121,12 @@ class AuthorizationManager:
         self.logger.debug("Handling cli")
 
         if arguments.authorization_code:
-            response = self.session.get(CODE_URL + arguments.authorization_code)
+            try:
+                response = self.session.get(CODE_URL + arguments.authorization_code)
+            except (requests.ConnectionError, requests.Timeout) as e:
+                self.logger.error(f"Failed to reach GOG authentication server: {e}")
+                print(json.dumps({"error": True}))
+                return
 
             if not response.ok:
                 print(json.dumps({"error": True}))

--- a/gogdl/auth.py
+++ b/gogdl/auth.py
@@ -124,7 +124,9 @@ class AuthorizationManager:
             try:
                 response = self.session.get(CODE_URL + arguments.authorization_code)
             except (requests.ConnectionError, requests.Timeout) as e:
-                self.logger.error(f"Failed to reach GOG authentication server: {e}")
+                # Don't log the exception itself, it embeds the request url
+                # and that carries the client secret and the auth code
+                self.logger.error(f"Failed to reach GOG ({type(e).__name__})")
                 print(json.dumps({"error": True}))
                 return
 

--- a/gogdl/auth.py
+++ b/gogdl/auth.py
@@ -124,8 +124,7 @@ class AuthorizationManager:
             try:
                 response = self.session.get(CODE_URL + arguments.authorization_code)
             except (requests.ConnectionError, requests.Timeout) as e:
-                # Don't log the exception itself, it embeds the request url
-                # and that carries the client secret and the auth code
+                # Don't log the exception itself because it contains client id and client secret
                 self.logger.error(f"Failed to reach GOG ({type(e).__name__})")
                 print(json.dumps({"error": True}))
                 return

--- a/gogdl/net.py
+++ b/gogdl/net.py
@@ -1,0 +1,13 @@
+# requests has no timeout by default. Matters when ipv6 is advertised but not
+# routed: the connect stalls and we only get to the ipv4 address once it times out
+import requests
+
+# connect, read
+TIMEOUT = (10, 30)
+
+
+class Session(requests.Session):
+    def request(self, method, url, **kwargs):
+        if kwargs.get("timeout") is None:
+            kwargs["timeout"] = TIMEOUT
+        return super().request(method, url, **kwargs)

--- a/gogdl/net.py
+++ b/gogdl/net.py
@@ -1,5 +1,5 @@
-# requests has no timeout by default. Matters when ipv6 is advertised but not
-# routed: the connect stalls and we only get to the ipv4 address once it times out
+# Add request timeouts. Matters when ipv6 is given by ISP but not routed
+# python will automatically fallback to ipv4 when the ipv6 request timeouts
 import requests
 
 # connect, read


### PR DESCRIPTION
Move to  net.Session instead of requests.session which offers automatic timeout and ipv4 fallback